### PR TITLE
fix: generate XSRF token with another endpoint

### DIFF
--- a/postman/test/Gravitee.io-Test.Suite-Create.Application.postman_collection.json
+++ b/postman/test/Gravitee.io-Test.Suite-Create.Application.postman_collection.json
@@ -26,7 +26,7 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{GRAVITEEIO_MGMT_URL}}/management/organizations/DEFAULT/environments/DEFAULT/portal",
+					"raw": "{{GRAVITEEIO_PORTAL_URL}}/portal/environments/DEFAULT/configuration",
 					"host": [
 						"{{GRAVITEEIO_MGMT_URL}}"
 					],


### PR DESCRIPTION
Since gravitee-io/issues#5435, the resource used to generate a XSRF token is protected. So postman tests that need this token fail.